### PR TITLE
Add label RHEL_VERSION

### DIFF
--- a/source/system/system.go
+++ b/source/system/system.go
@@ -29,6 +29,7 @@ import (
 var osReleaseFields = [...]string{
 	"ID",
 	"VERSION_ID",
+	"RHEL_VERSION",
 }
 
 // Implement FeatureSource interface


### PR DESCRIPTION
add RHEL_VERSION label, this will allow us better support release
version injection when dealing with kernel modules that require a
specific --releasever= option

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>