### PR TITLE
Fix component information missing in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ reviewers:
   - jmencak
   - Deepthidharwar
   - ArangoGutierrez
+component: "Node Feature Discovery Operator"


### PR DESCRIPTION
Bugzilla component information missing for image
containers/node-feature-discovery in OCP v4.X

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>