### PR TITLE
Support for additional cpu features

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -59,7 +59,10 @@ The **cpu** feature source supports the following labels:
 | cpuid                   | &lt;cpuid flag&gt; | CPU capability is supported
 | hardware_multithreading |                    | Hardware multithreading, such as Intel HTT, enabled (number of logical CPUs is greater than physical CPUs)
 | power                   | sst_bf.enabled     | Intel SST-BF ([Intel Speed Select Technology][intel-sst] - Base frequency) enabled
-| [pstate][intel-pstate]  | turbo              | Set to 'true' if turbo frequencies are enabled in Intel pstate driver, set to 'false' if they have been disabled.
+| [pstate][intel-pstate]  | status             | The status of the Intel pstate driver when in use and enabled, either 'active' or 'passive'.
+|                         | turbo              | Set to 'true' if turbo frequencies are enabled in Intel pstate driver, set to 'false' if they have been disabled.
+|                         | scaling_governor   | The value of the Intel pstate scaling_governor when in use, either 'powersave' or 'performance'.
+| cstate                  | enabled            | Set to 'true' if cstates are set in the intel_idle driver, otherwise set to 'false'.
 | [rdt][intel-rdt]        | RDTMON             | Intel RDT Monitoring Technology
 |                         | RDTCMT             | Intel Cache Monitoring (CMT)
 |                         | RDTMBM             | Intel Memory Bandwidth Monitoring (MBM)

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -143,6 +143,14 @@ func (s *Source) Discover() (source.Features, error) {
 		features["rdt."+f] = true
 	}
 
+	// Detect cstate configuration
+	cstate, err := detectCstate()
+	if err != nil {
+		log.Printf("ERROR: failed to detect cstate: %v", err)
+	} else {
+		features["cstate.enabled"] = cstate
+	}
+
 	return features, nil
 }
 

--- a/source/cpu/cstate.go
+++ b/source/cpu/cstate.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"openshift/node-feature-discovery/source"
+)
+
+// Discover if c-states are enabled
+func detectCstate() (bool, error) {
+	// When the intel_idle driver is in use (default), check setting of max_cstates
+	driver, err := ioutil.ReadFile(source.SysfsDir.Path("devices/system/cpu/cpuidle/current_driver"))
+	if err != nil {
+		return false, fmt.Errorf("cannot get driver for cpuidle: %s", err.Error())
+	}
+
+	if strings.TrimSpace(string(driver)) != "intel_idle" {
+		// Currently only checking intel_idle driver for cstates
+		return false, fmt.Errorf("intel_idle driver is not in use: %s", string(driver))
+	}
+
+	data, err := ioutil.ReadFile(source.SysfsDir.Path("module/intel_idle/parameters/max_cstate"))
+	if err != nil {
+		return false, fmt.Errorf("cannot determine cstate from max_cstates: %s", err.Error())
+	}
+	cstates, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return false, fmt.Errorf("non-integer value of cstates: %s", err.Error())
+	}
+
+	return cstates > 0, nil
+}


### PR DESCRIPTION
This adds additional cpu features:

pstate enable from status of intel_pstate driver
pstate performance and powersave settings from scaling_governor
cstate enable from max_cstates in intel_idle driver

This is a backport from
https://github.com/kubernetes-sigs/node-feature-discovery/pull/463