### PR TITLE
Bug 1868799: Mount /usr inside the Pod

### DIFF
--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -104,6 +104,12 @@ spec:
             - name: host-sys
               mountPath: "/host-sys"
               readOnly: true
+            - name: host-usr-lib
+              mountPath: "/host-usr/lib"
+              readOnly: true
+            - name: host-usr-src
+              mountPath: "/host-usr/src"
+              readOnly: true
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
               readOnly: true
@@ -128,6 +134,12 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: host-usr-lib
+          hostPath:
+            path: "/usr/lib"
+        - name: host-usr-src
+          hostPath:
+            path: "/usr/src"
         - name: source-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/source.d/"

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -151,6 +151,12 @@ spec:
             - name: host-sys
               mountPath: "/host-sys"
               readOnly: true
+            - name: host-usr-lib
+              mountPath: "/host-usr/lib"
+              readOnly: true
+            - name: host-usr-src
+              mountPath: "/host-usr/src"
+              readOnly: true
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
               readOnly: true
@@ -182,6 +188,12 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: host-usr-lib
+          hostPath:
+            path: "/usr/lib"
+        - name: host-usr-src
+          hostPath:
+            path: "/usr/src"
         - name: source-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/source.d/"

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -61,6 +61,12 @@ spec:
             - name: host-sys
               mountPath: "/host-sys"
               readOnly: true
+            - name: host-usr-lib
+              mountPath: "/host-usr/lib"
+              readOnly: true
+            - name: host-usr-src
+              mountPath: "/host-usr/src"
+              readOnly: true
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
               readOnly: true
@@ -93,6 +99,12 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: host-usr-lib
+          hostPath:
+            path: "/usr/lib"
+        - name: host-usr-src
+          hostPath:
+            path: "/usr/src"
         - name: source-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/source.d/"

--- a/source/config.go
+++ b/source/config.go
@@ -28,6 +28,8 @@ var (
 	EtcDir = HostDir(pathPrefix + "etc")
 	// SysfsPath is where the /sys directory of the system to be inspected is located
 	SysfsDir = HostDir(pathPrefix + "sys")
+	// UsrPath is where the /usr directory of the system to be inspected is located
+	UsrDir = HostDir(pathPrefix + "usr")
 )
 
 // HostDir is a helper for handling host system directories

--- a/source/internal/kernelutils/kernel_kconfig.go
+++ b/source/internal/kernelutils/kernel_kconfig.go
@@ -62,19 +62,19 @@ func ParseKconfig(configPath string) (map[string]string, error) {
 	if err != nil {
 		searchPaths = []string{
 			"/proc/config.gz",
-			"/usr/src/linux/.config",
+			source.UsrDir.Path("src/linux/.config"),
 		}
 	} else {
 		// from k8s.io/system-validator used by kubeadm
 		// preflight checks
 		searchPaths = []string{
 			"/proc/config.gz",
-			"/usr/src/linux-" + kVer + "/.config",
-			"/usr/src/linux/.config",
-			"/usr/lib/modules/" + kVer + "/config",
-			"/usr/lib/ostree-boot/config-" + kVer,
-			"/usr/lib/kernel/config-" + kVer,
-			"/usr/src/linux-headers-" + kVer + "/.config",
+			source.UsrDir.Path("src/linux-" + kVer + "/.config"),
+			source.UsrDir.Path("src/linux/.config"),
+			source.UsrDir.Path("lib/modules/" + kVer + "/config"),
+			source.UsrDir.Path("lib/ostree-boot/config-" + kVer),
+			source.UsrDir.Path("lib/kernel/config-" + kVer),
+			source.UsrDir.Path("src/linux-headers-" + kVer + "/.config"),
 			"/lib/modules/" + kVer + "/build/.config",
 			source.BootDir.Path("config-" + kVer),
 		}

--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -338,6 +338,16 @@ func nfdWorkerPodSpec(image string, extraArgs []string) v1.PodSpec {
 						MountPath: "/host-sys",
 						ReadOnly:  true,
 					},
+					{
+						Name:      "host-usr-lib",
+						MountPath: "/host-usr/lib",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "host-usr-src",
+						MountPath: "/host-usr/src",
+						ReadOnly:  true,
+					},
 				},
 			},
 		},
@@ -367,6 +377,24 @@ func nfdWorkerPodSpec(image string, extraArgs []string) v1.PodSpec {
 				VolumeSource: v1.VolumeSource{
 					HostPath: &v1.HostPathVolumeSource{
 						Path: "/sys",
+						Type: newHostPathType(v1.HostPathDirectory),
+					},
+				},
+			},
+			{
+				Name: "host-usr-lib",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/usr/lib",
+						Type: newHostPathType(v1.HostPathDirectory),
+					},
+				},
+			},
+			{
+				Name: "host-usr-src",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/usr/src",
 						Type: newHostPathType(v1.HostPathDirectory),
 					},
 				},


### PR DESCRIPTION
Mount /usr as /host-usr inside the pod to allow NFD to find the kernel
configuration file inside /usr.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>

Reason for the PR: In RHCOS on s390x there is no kernel-config inside `/boot`. The file is only present inside `/usr/lib/modules`.

Fixes #32.