### PR TITLE
Bug 1959390: [release-4.7] Update system.go

### DIFF
--- a/source/system/system.go
+++ b/source/system/system.go
@@ -30,6 +30,7 @@ var osReleaseFields = [...]string{
 	"ID",
 	"VERSION_ID",
 	"RHEL_VERSION",
+	"OPENSHIFT_VERSION",
 }
 
 // Implement FeatureSource interface


### PR DESCRIPTION
Expose consistently RHEL and OPENSHIFT_VERSION 