### PR TITLE
Update system.go

### DIFF
--- a/source/system/system.go
+++ b/source/system/system.go
@@ -29,6 +29,8 @@ import (
 var osReleaseFields = [...]string{
 	"ID",
 	"VERSION_ID",
+	"RHEL_VERSION", 
+	"OPENSHIFT_VERSION",
 }
 
 // Implement FeatureSource interface


### PR DESCRIPTION
Expose consistently RHEL and OPENSHIFT_VERSION for 4.6 onwards