### PR TITLE
PSAP-524: use OSTREE_VERSION instead of VERSION

### DIFF
--- a/source/system/system.go
+++ b/source/system/system.go
@@ -32,7 +32,7 @@ var osReleaseFields = [...]string{
 	"VERSION_ID",
 	"RHEL_VERSION",
 	"OPENSHIFT_VERSION",
-	"VERSION",
+	"OSTREE_VERSION",
 }
 
 const Name = "system"


### PR DESCRIPTION
The spec of `/etc/os-release` `VERSION` specifies that the value is
"user-friendly" [1]:

> A string identifying the operating system version, excluding any OS
> name information, possibly including a release code name, and suitable
> for presentation to the user. This field is optional. Example:
> "VERSION=17" or "VERSION="17 (Beefy Miracle)"".

In RHCOS, currently `VERSION == OSTREE_VERSION`, but `OSTREE_VERSION`
should be more future-proof.

1: https://www.linux.org/docs/man5/os-release.html