### PR TITLE
Trim single quotes in parseOSRelease

### DIFF
--- a/source/system/system.go
+++ b/source/system/system.go
@@ -93,7 +93,7 @@ func parseOSRelease() (map[string]string, error) {
 	for s.Scan() {
 		line := s.Text()
 		if m := re.FindStringSubmatch(line); m != nil {
-			release[m[1]] = strings.Trim(m[2], `"`)
+			release[m[1]] = strings.Trim(m[2], `"'`)
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick of pending upstream commit https://github.com/kubernetes-sigs/node-feature-discovery/pull/606

Currently when parsing /etc/os-release, NFD assumes all all values are surrounded by double quotes ".
In some OS's, such as RHCOS, the OSTREE_VERSION is surrounded by single quotes.

```
VERSION="48.84.202107271439-0"
ID="rhcos"
...
OPENSHIFT_VERSION="4.8"
RHEL_VERSION="8.4"
OSTREE_VERSION='48.84.202107271439-0'
```

Signed-off-by: David Gray <dagray@redhat.com>