### PR TITLE
Bug 2008092: [release-4.8] Expose host /etc/os-release OSTREE_VERSION

### DIFF
--- a/source/system/system.go
+++ b/source/system/system.go
@@ -32,6 +32,7 @@ var osReleaseFields = [...]string{
 	"VERSION_ID",
 	"RHEL_VERSION",
 	"OPENSHIFT_VERSION",
+	"VERSION",
 }
 
 // Implement FeatureSource interface

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -91,7 +91,7 @@ func parseOSRelease() (map[string]string, error) {
 	for s.Scan() {
 		line := s.Text()
 		if m := re.FindStringSubmatch(line); m != nil {
-			release[m[1]] = strings.Trim(m[2], `"`)
+			release[m[1]] = strings.Trim(m[2], `"'`)
 		}
 	}
 

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -32,7 +32,7 @@ var osReleaseFields = [...]string{
 	"VERSION_ID",
 	"RHEL_VERSION",
 	"OPENSHIFT_VERSION",
-	"VERSION",
+	"OSTREE_VERSION",
 }
 
 // Implement FeatureSource interface


### PR DESCRIPTION
This is a backport of what we already merged for 4.9 and 4.10:

[Bug 2008092](https://bugzilla.redhat.com/show_bug.cgi?id=2008092)

---

* [PSAP-524](https://issues.redhat.com/browse/PSAP-524) `expose host /etc/os-release VERSION`

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

---

* [PSAP-524](https://issues.redhat.com/browse/PSAP-524) `use OSTREE_VERSION instead of VERSION`

The spec of `/etc/os-release` `VERSION` specifies that the value is
"user-friendly" [1]:

> A string identifying the operating system version, excluding any OS
> name information, possibly including a release code name, and suitable
> for presentation to the user. This field is optional. Example:
> "VERSION=17" or "VERSION="17 (Beefy Miracle)"".

In RHCOS, currently `VERSION == OSTREE_VERSION`, but `OSTREE_VERSION`
should be more future-proof.

1: https://www.linux.org/docs/man5/os-release.html

---

* `Trim single quotes in parseOSRelease`

Signed-off-by: David Gray <dagray@redhat.com>

---