### PR TITLE
Bug 2057569: nfd-worker: drop 'custom-' prefix from matchFeatures custom rules

### DIFF
--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -498,8 +498,8 @@ func getFeatureLabels(source source.LabelSource, labelWhiteList regexp.Regexp) (
 	// Prefix for labels in the default namespace
 	prefix := source.Name() + "-"
 	switch source.Name() {
-	case "local":
-		// Do not prefix labels from the hooks
+	case "local", "custom":
+		// Do not prefix labels from the custom rules, hooks or feature files
 		prefix = ""
 	}
 


### PR DESCRIPTION
Do not prefix label names from the new matchFeatures/matchAny custom
rules with "custom-". We want to have the same result (set of labels)
from a rule independent of whether it has been specified in worker
config or in a NodeFeatureRule CRs. Legacy matchOn rules (not available
in NodeFeatureRule CRs) are intact, i.e. still prefixed, in order to
retain backwards compatibility.