### PR TITLE
adjusting operand to support u/s crds

### DIFF
--- a/api/nfd/v1alpha1/doc.go
+++ b/api/nfd/v1alpha1/doc.go
@@ -17,5 +17,5 @@ limitations under the License.
 // Package v1alpha1 is the v1alpha1 version of the nfd API.
 // +k8s:deepcopy-gen=package
 // +kubebuilder:object:generate=true
-// +groupName=nfd.openshift.io
+// +groupName=nfd.k8s-sigs.io
 package v1alpha1

--- a/api/nfd/v1alpha1/register.go
+++ b/api/nfd/v1alpha1/register.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "nfd.openshift.io", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "nfd.k8s-sigs.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is the scheme builder for this API.
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)

--- a/deployment/base/nfd-crds/nfd-api-crds.yaml
+++ b/deployment/base/nfd-crds/nfd-api-crds.yaml
@@ -412,7 +412,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   name: nodefeaturerules.nfd.openshift.io
 spec:
-  group: nfd.openshift.io
+  group: nfd.k8s-sigs.io
   names:
     kind: NodeFeatureRule
     listKind: NodeFeatureRuleList

--- a/vendor/github.com/openshift/node-feature-discovery/api/nfd/v1alpha1/doc.go
+++ b/vendor/github.com/openshift/node-feature-discovery/api/nfd/v1alpha1/doc.go
@@ -17,5 +17,5 @@ limitations under the License.
 // Package v1alpha1 is the v1alpha1 version of the nfd API.
 // +k8s:deepcopy-gen=package
 // +kubebuilder:object:generate=true
-// +groupName=nfd.openshift.io
+// +groupName=nfd.k8s-sigs.io
 package v1alpha1

--- a/vendor/github.com/openshift/node-feature-discovery/api/nfd/v1alpha1/register.go
+++ b/vendor/github.com/openshift/node-feature-discovery/api/nfd/v1alpha1/register.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "nfd.openshift.io", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "nfd.k8s-sigs.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is the scheme builder for this API.
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)


### PR DESCRIPTION
This commits makes operand to start to use the upstream crds instead of the downstream
ones for NodeFeature, NodeFeatureRule and NodeFeatureGroup resources.
This Pr completes https://github.com/openshift/cluster-nfd-operator/pull/419

/cc @yevgeny-shnaidman @ybettan 