### PR TITLE
removing error log in case swap not enabled

### DIFF
--- a/source/memory/memory.go
+++ b/source/memory/memory.go
@@ -146,7 +146,11 @@ func detectSwap() (map[string]string, error) {
 	procBasePath := hostpath.ProcDir.Path("swaps")
 	lines, err := getNumberOfNonEmptyLinesFromFile(procBasePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read swaps file: %w", err)
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{"enabled": "false",}, nil
+		} else {
+			return nil, fmt.Errorf("failed to read swaps file: %w", err)
+		}
 	}
 	// /proc/swaps has a header row
 	// If there is more than a header then we assume we have swap.


### PR DESCRIPTION
in case memory swap is not enabled(RCHOS), the swap file is missing, and the code logs an error in the log. This PR check if the file is missing, and if it is missing then the swap fieature is marked as "not enabled" in the NodeFeature