### PR TITLE
OCPBUGS-78691: fix hermetic build binary path issue in dockerfile for release-4.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 # Do actual build
 ARG VERSION=v0.10.0
 ARG HOSTMOUNT_PREFIX=/host-
-RUN make install VERSION=${VERSION} HOSTMOUNT_PREFIX=${HOSTMOUNT_PREFIX}
+RUN make build VERSION=${VERSION} HOSTMOUNT_PREFIX=${HOSTMOUNT_PREFIX}
 
 # Create full variant of the production image
 FROM registry.ci.openshift.org/ocp/4.14:base
@@ -16,4 +16,4 @@ FROM registry.ci.openshift.org/ocp/4.14:base
 ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
 
 COPY --from=builder /go/node-feature-discovery/deployment/components/worker-config/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
-COPY --from=builder /go/bin/* /usr/bin/
+COPY --from=builder /go/node-feature-discovery/bin/* /usr/bin/


### PR DESCRIPTION
## Summary
Fix hermetic build binary path issue in dockerfile

## Problem
**Before:** Hermetic (Cachito/cachi2) builds override GOBIN, so go install places binaries in a different location than /go/bin, causing COPY --from=builder /go/bin/* /usr/bin/ to fail.

**After:** Replace make install (which uses go install) with make build (which uses go build) and explicitly output binaries to /go/node-feature-discovery/bin, then copy from that deterministic path into /usr/bin/.