### PR TITLE
Adding AI workflow for upstream backporting to downstream

### DIFF
--- a/.claude/commands
+++ b/.claude/commands
@@ -1,0 +1,1 @@
+../.cursor/commands

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.cursor/skills

--- a/.cursor/commands/cherry-pick-flow.md
+++ b/.cursor/commands/cherry-pick-flow.md
@@ -1,0 +1,18 @@
+---
+description: "Cherry-pick a sequential timeline of commits from an external repository into the current repository with iterative make validations."
+---
+# /cherry-pick
+
+Use this command to safely pull a range of commits chronologically from an external repository into this workspace.
+
+## Usage
+`/cherry-pick <path_to_other_repo> <starting_commit_sha>`
+
+## System Mapping
+1. Extract the local folder path to the external repository from the first argument.
+2. Extract the starting commit hash from the second argument.
+3. Open, read, and strictly follow the execution instructions located inside `.cursor/skills/cross-repo-picker.md`.
+4. Execute the loop **yourself**, one commit at a time — do **not** use helper scripts (`run-cherry-pick-queue.sh`, `process-cherry-pick.sh`, or similar batch automation).
+5. Dispatch the execution loop passing the arguments:
+   - Source Repo: $ARGUMENT_1
+   - Start Commit: $ARGUMENT_2

--- a/.cursor/skills/cross-repo-picker.md
+++ b/.cursor/skills/cross-repo-picker.md
@@ -1,0 +1,90 @@
+# Skill: Iterative Cross-Repository Cherry-Picker
+
+This skill executes a step-by-step sequential cherry-pick loop from an external repository while maintaining local workspace safety.
+
+## Three-phase compatibility model
+
+Cherry-picking across different Go/K8s baselines uses three phases. Handlers must respect phase boundaries:
+
+| Phase | When | Handler | Action |
+|-------|------|---------|--------|
+| **1 — Defer** | Standard cherry-pick needs newer Go/K8s API | `standard-picker-handler.md` | Use older compatible API; record in `.cursor/compatibility-debt.jsonl` |
+| **2 — Upgrade** | Commit explicitly bumps Go/K8s (toolchain or dependabot k8sio) | `toolchain-handler.md` / dependabot toolchain mode | Full upgrade incl. `Dockerfile.node-feature-discovery-build` |
+| **3 — Restore** | Immediately after Phase 2 build passes | `compatibility-debt.md` | Re-apply upstream APIs from debt ledger; build & commit |
+
+## Global Execution Rules
+* **One commit at a time — no helper scripts:** Process the queue **manually**, commit by commit, by reading the relevant handler skill and running git/skipper commands yourself.
+* **Never** invoke batch scripts (e.g. `run-cherry-pick-queue.sh`, `process-cherry-pick.sh`) or write new automation to loop through the queue. After each commit is applied or skipped, run validation, then move to the **next single commit** — do not batch cherry-picks or builds across multiple commits.
+* **Verbose Logging:** Log every atomic action, decision, skipped commit, or successful merge in the chat console in real-time. Do not execute silently.
+* **Debt logging:** Any Phase 1 downgrade must log `COMPAT-DEBT: …`. Any Phase 3 restoration must log `COMPAT-RESTORE: …`.
+
+## Step 1: Commit Range Extraction
+1. Navigate to the external repository path provided by the user.
+2.  Generate an ordered list of all commits from `<starting_commit_sha>` up to `HEAD`, in the exact order they appear when scrolling **up** in `git log` output.
+   * *Formula:* Run `git log --format="%H|%an|%s"` (no other flags) in the source repo, pipe the output to a file, find the line containing `<starting_commit_sha>`, take that line and all lines above it (toward HEAD), then reverse them so `<starting_commit_sha>` is first and `HEAD` is last. Shell one-liner: `git log --format="%H|%an|%s" | head -n $(git log --format="%H" | grep -n <starting_commit_sha> | cut -d: -f1) | tac`
+3. Parse this list into a clean state array containing `[SHA, Author, Commit Message]`. 
+4. Present the list to the user and wait for his approval to proceed.
+
+## Step 2: Prepare Target Directory
+1. Navigate to target directory
+2. Check if `sig` target is defined in the .git/config. If it is not defined, add it to the .git/config using `git remote add sig https://github.com/kubernetes-sigs/node-feature-discovery`
+3. Run `git fetch sig`
+4. Ensure `.cursor/compatibility-debt.jsonl` exists (create empty if missing).
+
+## Step 3: The Iterative Execution Loop
+Process **exactly one commit** per iteration. For that commit, evaluate the **Author** and **commit message** and route:
+
+### Use Case 1: Prow Robot (Skip)
+* **Condition:** Author is `"Kubernetes Prow Robot"`.
+* **Action:** Delegate immediately to `.cursor/skills/handlers/prow-handler.md`.
+
+### Use Case 2: Toolchain upgrade (Phase 2)
+* **Condition:** Commit message matches `Bump Golang to`, `go.mod: update all k8s`, `go.mod: bump kubernetes`, **or** dependabot diff changes root `go` / multiple `k8s.io/*` (see `dependabot-handler.md` routing).
+* **Action:** Delegate to `.cursor/skills/handlers/toolchain-handler.md`, then run Phase 3 from `compatibility-debt.md`.
+
+### Use Case 3: Dependabot (package or toolchain)
+* **Condition:** Author is `"dependabot[bot]"`.
+* **Action:** Delegate to `.cursor/skills/handlers/dependabot-handler.md` (routes to package mode or toolchain mode internally).
+
+### Use Case 4: Standard Commits (Cherry-Pick & Resolve, Phase 1)
+* **Condition:** Any other author.
+* **Action:** Delegate to `.cursor/skills/handlers/standard-picker-handler.md`.
+
+---
+
+## Step 4: Post-Commit Validation & Pacing
+Immediately after a handler successfully completes a commit lifecycle (or a skip occurs):
+
+1. **Sanity Check:** If a code change occurred, check that code compiles:
+```bash
+   skipper run make build
+```
+   On failure: fix once and retry; ask the user only if the retry fails or auth is required.
+
+2. **Phase 3 check:** If the commit just applied was a toolchain upgrade (Use Case 2 or dependabot toolchain mode), scan `.cursor/compatibility-debt.jsonl` and restore all pending entries before advancing the queue. Execute `Sanity Check` before advancing the queue.
+
+3. **Advance:** Log the result (`APPLIED`, `SKIPPED`, or `FAILED`) for this commit, then return to Step 3 for the **next** commit only. Repeat until the queue is exhausted or a hard failure requires user input.
+
+## Step 5: Final Test Run
+
+After the queue is fully exhausted and the final `skipper run make build` has passed, run the full test suite:
+
+```bash
+skipper run make test
+```
+
+* If all tests pass, proceed to Step 6.
+* If tests fail, analyze the failures, fix them (import path mismatches, compatibility issues, etc.), re-run `skipper run make test`, and commit any fixes with a descriptive message before proceeding.
+* Ask the user only if tests still fail after one fix attempt.
+
+## Step 6: Cleanup
+
+Once the queue is fully exhausted (all commits applied or skipped), delete the runtime artifacts created during this run:
+
+```bash
+rm -f .cursor/compatibility-debt.jsonl
+rm -f .cursor/cherry-pick-queue.txt
+rm -f .cursor/cherry-pick-progress.txt
+```
+
+Do **not** delete the skill/handler markdown files or the command file — they are reusable for future runs.

--- a/.cursor/skills/handlers/compatibility-debt.md
+++ b/.cursor/skills/handlers/compatibility-debt.md
@@ -1,0 +1,30 @@
+# Ledger: Compatibility Debt (API Downgrades)
+
+Tracks source-code adaptations made during cherry-picks **before** the matching Go/K8s toolchain upgrade lands. Each entry is reverted in Phase 3 once the toolchain commit has been applied and `skipper run make build` passes.
+
+## Ledger file
+Maintain at: `.cursor/compatibility-debt.jsonl`
+
+Each line is one JSON object:
+```json
+{"commit":"<upstream-sha-being-picked>","file":"path/to/file.go","reason":"API X requires go 1.26","upstream_api":"cache.ToListWatcherWithWatchListSemantics","local_api":"&cache.ListWatch{","restore_after":"go-toolchain-upgrade"}
+```
+
+## Phase 1 — Record debt (standard-picker-handler)
+When you downgrade or substitute an API/package call so the patch compiles on the **current** Go/K8s toolchain:
+1. Apply the compatible alternative.
+2. Append one ledger entry per adaptation.
+3. Log: `COMPAT-DEBT: recorded <file> — will restore after toolchain upgrade`.
+
+## Phase 3 — Restore debt (post toolchain upgrade)
+After any handler completes a Go or K8s toolchain upgrade and build passes:
+1. Read `.cursor/compatibility-debt.jsonl`.
+2. For each open entry, re-apply the **upstream** API/version from the original patch intent.
+3. Run `skipper run make build` autonomously.
+4. On success, remove the entry from the ledger. On failure after one fix attempt, ask the user.
+5. Commit restorations separately or amend the toolchain commit — prefer a dedicated commit: `restore: re-enable deferred APIs after toolchain upgrade`.
+
+## When NOT to record debt
+* Import-path rewrites (`sigs.k8s.io` → `github.com/openshift/...`) — permanent downstream difference.
+* Intentionally ignored files (Makefile, docs, helm) — not debt.
+* Prow-skip or helm-skip — no code landed.

--- a/.cursor/skills/handlers/dependabot-handler.md
+++ b/.cursor/skills/handlers/dependabot-handler.md
@@ -1,0 +1,35 @@
+# Handler: Dependabot Go Module Differential Sync
+
+This sub-skill handles dependency updates from Dependabot by translating git diffs into clean local native Go commands.
+
+**Execution policy:** All `skipper run …` steps run autonomously. Never ask before running them.
+
+## Routing: two dependabot modes
+
+Inspect the `go.mod` diff **before** acting:
+
+| Diff signal | Handler mode |
+|-------------|--------------|
+| Changes root `go` directive **or** ≥2 `k8s.io/*` modules **or** `k8s.io/kubernetes` | **Toolchain mode** → follow `toolchain-handler.md` (Phase 2) in full |
+| Single third-party module bump only (grpc, ginkgo, runc, …) | **Package mode** → steps below |
+
+## Package mode (single dependency)
+
+**CRITICAL SAFETY GUARDRAIL:** do not use `replace` directive, unless it was already defined in the go.mod for the specific package.
+**CRITICAL SAFETY GUARDRAIL (USER INTERVENTION):** If an authorization token is required for pulling any image or dependency, STOP immediately, log the issue, and ask the user to provide authorization/tokens. Otherwise, proceed completely autonomously.
+
+1. **Analyze Diffs:** Inspect the changes made specifically to the `go.mod` file inside the targeted external commit hash.
+2. **Execute Go Fetch:** For each added or updated package version found in that diff, execute:
+```bash
+   skipper run go get <package>@<version>
+   skipper run go mod tidy
+   skipper run go mod vendor
+   git commit -am "<original_commit_message>"
+```
+## Toolchain mode (Go / K8s upgrade)
+
+When dependabot touches the toolchain, **do not** stop at `go get` for one package. Delegate entirely to `toolchain-handler.md`:
+* Apply all module bumps from the diff (and any paired Markus `go.mod` commits if needed for consistency).
+* Update `Dockerfile.node-feature-discovery-build` base image to match the new Go version.
+* `skipper run go mod tidy`, `skipper run go mod vendor`, `skipper run make build`.
+* Run Phase 3 compatibility-debt restoration from `compatibility-debt.md`.

--- a/.cursor/skills/handlers/prow-handler.md
+++ b/.cursor/skills/handlers/prow-handler.md
@@ -1,0 +1,8 @@
+# Handler: Prow Robot Commit Skipper
+
+This sub-skill handles automated CI/CD commits that should not be merged into the local repository.
+
+## Execution Steps
+1. Log a message in the chat informing the user that this commit belongs to the Prow Robot and is being skipped.
+2. Do not execute any `git cherry-pick` or file modifications.
+3. Advance the queue pointers immediately to the post-commit validation step in the main orchestrator.

--- a/.cursor/skills/handlers/standard-picker-handler.md
+++ b/.cursor/skills/handlers/standard-picker-handler.md
@@ -1,0 +1,44 @@
+# Handler: Standard Cherry-Picker & Conflict Resolver
+
+This sub-skill executes traditional cherry-picks and guides the agent through conflict mitigation.
+
+**Execution policy:** Cherry-pick and post-resolution `skipper run make build` run autonomously. Never ask before running skipper.
+
+## Execution Steps
+
+### 1. Pre-Pick File Evaluation
+Before or during the cherry-pick process, you must strictly enforce the following repository-specific rules:
+* **Rule 1 (Ignore Makefile Changes):** Any modifications, additions, or deletions to the `Makefile` must be completely ignored. Do not bring `Makefile` changes into this workspace.
+* **Rule 2 (Ignore Non-Source Files):** Completely ignore any incoming files that are not core source files. This includes, but is not limited to:
+  * Documentation files (e.g., `.md`, `.txt`, `/docs/` folders)
+  * Test/Mock generation scripts (e.g., scripts for `mockgen`, vector generation, or test automation helpers)
+* **Rule 3 (Phase 1 — compatibility, not toolchain upgrade):** If the incoming patch uses an API, package, or generated code that requires a **newer Go or K8s version** than the workspace currently has:
+  1. **Do not** bump `go` in `go.mod`, `k8s.io/*` versions, or `Dockerfile.node-feature-discovery-build` in this handler.
+  2. **Do** substitute an equivalent that compiles on the current toolchain (older function, revert generated-code hunk to pre-bump style, drop a hunk that only exists for newer client-go, etc.).
+  3. **Record** each substitution in `.cursor/compatibility-debt.jsonl` per `compatibility-debt.md`.
+  4. Log: `COMPAT-DEBT: <file> — deferred until toolchain upgrade`.
+  5. The toolchain-handler will land the real version bump later; compatibility-debt restoration (Phase 3) will then switch back to the upstream API.
+
+### 2. Execute Pick
+* Run `git cherry-pick <SHA>` to attempt bringing the patch into this workspace.
+
+### 3. Rewrite upstream import paths
+After the cherry-pick lands (cleanly or after conflict resolution), scan all files touched by the commit for Go imports starting with `sigs.k8s.io/node-feature-discovery/`. Replace them with `github.com/openshift/node-feature-discovery/`. This applies to both production and test files.
+
+Quick check:
+```bash
+git diff HEAD~1 --name-only -- '*.go' | xargs grep -l 'sigs.k8s.io/node-feature-discovery/' 2>/dev/null
+```
+For each match, replace `sigs.k8s.io/node-feature-discovery/` with `github.com/openshift/node-feature-discovery/` in the import block, stage the file, and amend the cherry-pick commit.
+
+### 4. Handle Potential Merge Conflicts
+* If the cherry-pick succeeds cleanly, exit this handler successfully.
+* If the cherry-pick halts due to a **Merge Conflict**:
+  1. **Log the Conflict:** Print details of the flagged files and the nature of the conflict in the chat log.
+  2. **Attempt Resolution:** Intelligently analyze and attempt to resolve the source conflicts matching the contextual logic of the incoming patch. Apply Rule 3 when resolution would require a toolchain bump.
+  3. **Conflict resolution (autonomous):** When multiple resolutions exist, choose the one that preserves upstream patch intent, downstream import paths, and handler ignore-rules (Makefile, docs, helm). Do **not** ask the user to pick.
+  4. Stage resolutions: `git add <resolved_files>` and run `git cherry-pick --continue`.
+  5. Run `skipper run make build` without asking.
+  6. **Ask the user only when**:
+     * **Auth required:** registry/token/credential needed for image or module pull.
+     * **Failure after retry:** `cherry-pick --continue` or `skipper run make build` fails twice for this commit despite a reasoned fix attempt.

--- a/.cursor/skills/handlers/toolchain-handler.md
+++ b/.cursor/skills/handlers/toolchain-handler.md
@@ -1,0 +1,46 @@
+# Handler: Go / K8s Toolchain Upgrade
+
+Handles commits whose **primary purpose** is bumping the Go toolchain or coordinated Kubernetes module versions — including:
+* `Bump Golang to vX.Y` (e.g. Markus Lehtonen, `3c5951cf`)
+* `go.mod: update all k8s modules to vX.Y.Z`
+* `go.mod: bump kubernetes to vX.Y.Z`
+* Dependabot commits that change the root `go` directive **or** multiple `k8s.io/*` modules in one diff
+
+## Phase 2 — Full toolchain upgrade (do everything needed)
+
+**CRITICAL:** A toolchain upgrade is never just a `go.mod` one-liner. Complete **all** of the following before committing:
+
+### 1. Apply version bumps
+* Mirror commit's `go.mod` diff with `skipper run go get` for each changed module.
+* Update `api/nfd/go.mod` if the upstream commit touches it.
+
+### 2. Update build images (mandatory)
+* Edit `Dockerfile.node-feature-discovery-build` so the `FROM` builder image matches the new Go version (e.g. `golang-1.26-openshift-…`).
+* **Do not** touch production Dockerfile, it will be updated manually by the user
+* **Do not** rely on upstream `Makefile` `BUILDER_IMAGE` defaults — downstream uses OpenShift builder tags; Makefile changes are ignored.
+
+#### Missing builder image — STOP and ask
+If the builder image for the new Go version does not exist in the registry (e.g. `manifest unknown`, 404, or image-pull error during `skipper run`):
+1. **Do NOT** fall back to the previous builder image or revert the Go version.
+2. **Do NOT** skip the commit.
+3. **STOP** and ask the user for the correct builder image tag. The user knows which images and OpenShift version suffixes are available.
+4. Resume the toolchain upgrade only after the user provides the correct image.
+
+### 3. Vendor and verify
+```bash
+skipper run go mod tidy
+skipper run go mod vendor
+skipper run make build
+```
+
+### 4. Commit
+```bash
+git commit -am "<original_commit_message>"
+```
+
+## Failure handling
+* If `skipper run go mod tidy` / `skipper run go get` pulls incompatible k8s module sets, apply the **coordinated** k8s bump commits together (dependabot k8sio group + Markus `go.mod` commits) in one toolchain session — do not land a partial k8s upgrade.
+* If build fails after image update, fix autonomously and re-run `skipper run make build` once. Ask the user only if the retry fails or the error indicates missing registry/auth credentials.
+
+## What to ignore from upstream toolchain commits
+* `Makefile` / `Tiltfile` builder-image defaults (Rule 1 in standard-picker) — already covered by `Dockerfile.node-feature-discovery-build` update above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# Node Feature Discovery (OpenShift fork)
+
+Kubernetes add-on that detects hardware features and system configuration on nodes and advertises them as node labels, annotations, and extended resources. This is the OpenShift downstream fork of [kubernetes-sigs/node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery).
+
+## Dev Environment
+
+- Go 1.25+ (see `go.mod`)
+- `podman` (or `docker` via `CONTAINER_COMMAND=docker`)
+- `kubectl`, `helm` for deployment workflows
+- `golangci-lint` for linting (installed by CI via `scripts/test-infra/verify.sh`)
+
+## Build
+
+```sh
+make build          # compile all binaries into bin/
+make image          # build container image (uses podman by default)
+make install        # go install all binaries
+```
+
+Binaries are built from `cmd/`:
+- `nfd-master` — cluster-side component, manages node labels
+- `nfd-worker` — node-side component, detects features
+- `nfd-topology-updater` — reports NUMA topology
+- `nfd-gc` — garbage collector for stale NFD labels
+- `nfd` — unified binary with subcommands
+- `kubectl-nfd` — kubectl plugin
+
+Override variables: `IMAGE_REGISTRY`, `IMAGE_TAG_NAME`, `CONTAINER_COMMAND`, `HOSTMOUNT_PREFIX`.
+
+## Test
+
+Run unit tests:
+
+```sh
+make test
+```
+
+This runs `go test -covermode=atomic -coverprofile=coverage.out ./cmd/... ./pkg/... ./source/...` and separately tests `api/nfd/...`.
+
+Test files live alongside source files (e.g. `pkg/nfd-master/nfd-master_test.go`).
+
+Run e2e tests (requires a running cluster and `KUBECONFIG`):
+
+```sh
+make e2e-test KUBECONFIG=<path>
+```
+
+E2e tests are in `test/e2e/` and use Ginkgo v2 (`github.com/onsi/ginkgo/v2`). Test data is in `test/e2e/data/`.
+
+## Code Style
+
+- Format: `gofmt -s` — run `make verify-gofmt` to check
+- Lint: `golangci-lint run --timeout 10m` via `make ci-lint`
+- Markdown lint: `make mdlint` (runs in a container)
+- Helm lint: `make helm-lint`
+- Log checker: `logcheck` with config at `scripts/test-infra/logcheck.conf`
+- Boilerplate header: `hack/boilerplate.go.txt`
+
+CI runs all checks via `scripts/test-infra/verify.sh`: gofmt, golangci-lint, helm lint, logcheck, unit tests, template freshness, kustomize overlay validation, Helm schema and README sync.
+
+## Architecture
+
+### Project Layout
+
+- `cmd/` — entry points for each binary
+- `pkg/` — core packages:
+  - `pkg/nfd-master/` — master server logic, label management, API controller
+  - `pkg/nfd-worker/` — worker logic, feature detection orchestration
+  - `pkg/nfd-topology-updater/` — topology updater logic
+  - `pkg/nfd-gc/` — garbage collector
+  - `api/nfd/v1alpha1/types.go` — CRD type definitions (`NodeFeatureRule`)
+  - `pkg/features/` — feature representation types
+  - `pkg/resourcemonitor/` — resource monitoring and pod resource scanning
+  - `pkg/utils/` — shared utilities (flags, hostpath, kubernetes helpers)
+- `source/` — feature source plugins (cpu, kernel, memory, network, pci, storage, system, usb, local, custom, fake)
+- `api/nfd/` — separate Go module for the NFD API types
+- `deployment/` — Kubernetes manifests:
+  - `deployment/base/` — kustomize base resources
+  - `deployment/overlays/` — kustomize overlays (default, prune, prometheus, etc.)
+  - `deployment/helm/node-feature-discovery/` — Helm chart
+  - `deployment/components/` — component configs (worker, master, topology-updater)
+- `hack/` — code generation and release scripts
+- `scripts/test-infra/` — CI scripts (build, verify, e2e)
+
+### Key Abstractions
+
+Feature sources in `source/` implement the `LabelSource` interface (see `source/source.go`). Each source detects specific hardware/OS features (CPU flags, kernel config, PCI devices, etc.) and returns them as labels.
+
+The master uses a `NodeFeatureRule` CRD (defined in `pkg/apis/nfd/`) to apply custom labeling rules.
+
+Communication between worker and master using NodeFeature object.
+
+### Multi-module Structure
+
+The project has two Go modules:
+- Root module: `github.com/openshift/node-feature-discovery` (Go 1.25)
+- API module: `github.com/openshift/node-feature-discovery/api/nfd` (Go 1.24, separate `go.mod`)
+
+The root module replaces the API module with a local path: `replace github.com/openshift/node-feature-discovery/api/nfd => ./api/nfd`.
+
+## Deployment
+
+Generate kustomize YAMLs:
+
+```sh
+make yamls
+```
+
+Deploy to a cluster:
+
+```sh
+make deploy
+```
+
+Clean NFD labels:
+
+```sh
+make deploy-prune
+```
+
+Update Helm values from config examples:
+
+```sh
+make templates
+```
+
+Generate CRDs and client code:
+
+```sh
+make generate
+```


### PR DESCRIPTION
The workflow is /cherry-pick-flow and receives 2 arguments:
1. <the upstream repo directory> - the local directory that contains the latest code for https://github.com/kubernetes-sigs/node-feature-discovery
2. <first upstream commit> - all the commits starting from the first and till the HEAD will be targets for backporing

The flow does the following:
1. builds a queue of the commits to backports
2. prepares the target repo directory by adding git remote target and fetching
3. cherry-pick each commit in queue (if needed, the merge commits are ignored)
4. per each successfull cherry-pick, runs "make build" to verify that the code compiles
5. once all the commits has been cherry-picked - runs unit-test "make test" and fixes if needed

The workflow can be used both by Cursor and by ClaudeCode